### PR TITLE
[RFC] Flags example: __mysql

### DIFF
--- a/type/__mysql/man.rst
+++ b/type/__mysql/man.rst
@@ -1,0 +1,42 @@
+cdist-type__postfix(7)
+======================
+
+NAME
+----
+cdist-type__mysql - Install MySQL or MariaDB
+
+
+DESCRIPTION
+-----------
+This space intentionally left blank.
+
+
+REQUIRED PARAMETERS
+-------------------
+None.
+
+
+OPTIONAL PARAMETERS
+-------------------
+None.
+
+
+EXAMPLES
+--------
+
+.. code-block:: sh
+
+    __mysql
+
+
+AUTHORS
+-------
+Daniel Fancsali <fancsali--@--gmail.com>
+
+
+COPYING
+-------
+Copyright \(C) 2022 Daniel Fancsali. You can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.

--- a/type/__mysql/manifest
+++ b/type/__mysql/manifest
@@ -1,0 +1,31 @@
+#!/bin/sh -e
+#
+# 2022 Daniel Fancsali (fancsali@gmail.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+__MYSQL=${__MYSQL-mariadb} # Set default value
+
+if [ "$__MYSQL" = "mysql" ]; then
+    __package mysql-server --state present
+elif [ "$__MYSQL" = "mariadb" ]; then
+    __package mariadb-server --state present
+else
+    echo "Neither the environment variable __MYSQL nor its default is set."
+    exit 1
+fi

--- a/type/__mysql/parameter/boolean
+++ b/type/__mysql/parameter/boolean
@@ -1,0 +1,1 @@
+mariadb

--- a/type/__mysql_database/gencode-remote
+++ b/type/__mysql_database/gencode-remote
@@ -18,20 +18,28 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-state_is="$( cat "$__object/explorer/state" )"
 
 state_should="$( cat "$__object/parameter/state" )"
-
-if [ "$state_is" = "$state_should" ]
-then
-    exit 0
-fi
 
 if [ -f "$__object/parameter/name" ]
 then
     name="$( cat "$__object/parameter/name" )"
 else
     name="$__object_id"
+fi
+
+# Figure out the current state
+# Not an explorer, as otherwise there'd be issues around the dependencies
+if [ -n "$( $__remote_exec "$__target_host" "mysql -B -N -e \"show databases like '$name'\"" )" ]
+then
+    state_is="present"
+else
+    state_is="absent"
+fi
+
+if [ "$state_is" = "$state_should" ]
+then
+    exit 0
 fi
 
 case "$state_should" in

--- a/type/__mysql_database/manifest
+++ b/type/__mysql_database/manifest
@@ -18,6 +18,11 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
+
+# Whatever the details, we'll need MySQL/MariaDB
+__mysql
+
+
 if [ -f "$__object/parameter/user" ]
 then
     user="$( cat "$__object/parameter/user" )"

--- a/type/__mysql_privileges/manifest
+++ b/type/__mysql_privileges/manifest
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+#
+# 2021 Daniel Fancsali (fancsali@gmail.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# We'll need MySQL/MariaDB
+__mysql

--- a/type/__mysql_user/gencode-remote
+++ b/type/__mysql_user/gencode-remote
@@ -18,14 +18,8 @@
 # along with cdist. If not, see <http://www.gnu.org/licenses/>.
 #
 
-state_is="$( cat "$__object/explorer/state" )"
 
 state_should="$( cat "$__object/parameter/state" )"
-
-if [ "$state_is" = "$state_should" ]
-then
-    exit 0
-fi
 
 if [ -f "$__object/parameter/name" ]
 then
@@ -47,6 +41,32 @@ else
     else
         password=''
     fi
+fi
+
+# Current state
+# Not an exploerer, to avoid issues with mysql not installed YET
+check_user="$( $__remote_exec "$__target_host" "mysql -B -N -e \"select user from mysql.user where user = '$name' and host = '$host'\"" )"
+
+if [ -n "$check_user" ]
+then
+    if [ -n "$password" ]
+    then
+        check_password="$( $__remote_exec "$__target_host" "mysql -B -N -e \"select user from mysql.user where user = '$name' and host = '$host' and password = password( '$password' )\"" )"
+    fi
+
+    if [ -n "$password" ] && [ -z "$check_password" ]
+    then
+        state_is='change-password'
+    else
+        state_is='present'
+    fi
+else
+    state_is='absent'
+fi
+
+if [ "$state_is" = "$state_should" ]
+then
+    exit 0
 fi
 
 if [ "$state_is" = 'absent' ] && [ "$state_should" = 'present' ]

--- a/type/__mysql_user/manifest
+++ b/type/__mysql_user/manifest
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+#
+# 2021 Daniel Fancsali (fancsali@gmail.com)
+#
+# This file is part of cdist.
+#
+# cdist is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cdist is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cdist. If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# We'll need MySQl/MariaDb to be installed
+__mysql


### PR DESCRIPTION
A POC example of how we might create a base type best practice, where:
- Users can use the dependent (`__mysql_*`) types without worrying about _MySQL_ **OR** _MariaDB_ installed; while still being able to chose in a simple manner, **without** the need to override the type and write custom code;
- At the same time, if one has a very specific need (e.g. install a hardened version from some private repo), they **can** easily **override** the base type

Let me know your thoughts...